### PR TITLE
PHXPM-1083 Added WARN to list of Event Types

### DIFF
--- a/src/CollectdWinService/WriteNetuitivePlugin.cs
+++ b/src/CollectdWinService/WriteNetuitivePlugin.cs
@@ -173,6 +173,7 @@ namespace Netuitive.CollectdWin
                         level = "CRITICAL";
                         break;
                     case "WARNING":
+                    case "WARN":
                         level = "WARNING";
                         break;
                     case "INFO":


### PR DESCRIPTION
Windows was sending the Level as "WARN" instead of "WARNING".  Both are now allowed.