### PR TITLE
Fixes #22 - Increases TTLMultiplier to 2.5 for additional leeway.

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,11 @@
+##v.next
+- Adjust checks multiplier to 2.5 for additional network latency leeway.
+
 ## v0.10.2
 - Add support for TCP port checks
 
 ## v0.10.1
-- Allow decimal check TTL multipliers. Show TTL multipliers in config with documentation 
+- Allow decimal check TTL multipliers. Show TTL multipliers in config with documentation
 
 ## v0.10.0
 - Add event source field
@@ -17,7 +20,7 @@
 
 ## v0.8.1
 - Added MongoDB plugin (requires .NET CLR 4.0)
-- Agent now requires .NET CLR 4.0 (see https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies) 
+- Agent now requires .NET CLR 4.0 (see https://docs.microsoft.com/en-us/dotnet/framework/migration-guide/versions-and-dependencies)
 
 ## v0.7.4
 - Fixed FQN in EC2 relationship (latest version to support .NET CLR 2.0)

--- a/src/CollectdWinService/config/ReadSystemChecks.config
+++ b/src/CollectdWinService/config/ReadSystemChecks.config
@@ -1,4 +1,4 @@
-﻿<ReadSystemChecks EnableAgentHeartbeat="true" HeartbeatTTLMultiplier="2.0">
+﻿<ReadSystemChecks EnableAgentHeartbeat="true" HeartbeatTTLMultiplier="2.5">
 
   <Checks>
 
@@ -8,11 +8,11 @@
                         For a Port check this is used as the name of the check in Metricly in the form "Name.Port".
         Port          - (port checks only) the TCP port to check. The agent verifies that the port is listening.
         Alias         - (optional) an alias to use for the check name in Metricly. If it is not supplied then the process name is used.
-        TTLMultiplier - (optional) sets the time-to-live of the check as a multiple of the agent execution interval. For example, if the agent is configured to collect data every 60 seconds (the default) and the check is 
-                        configured with a TTLMultiplier of 1.2 (the default) then the next check must be received by Metricly within 72 seconds in order to pass. The minimum allowed value is 1.0 but we recommended that 
-                        it is set slightly higher to allow for processing time and network latency etc.
+        TTLMultiplier - (optional) sets the time-to-live of the check as a multiple of the agent execution interval. For example, if the agent is configured to collect data every 60 seconds (the default) and the check is
+                        configured with a TTLMultiplier of 2.5 (the default) then the next check must be received by Metricly within 150 seconds in order to pass. The minimum allowed value is 1.0 but we recommended that
+                        it is set higher to allow for processing time and network latency etc.
         Examples:
-          <ServiceCheck Name="MSSQLSERVER" Alias="sqlservercheck" TTLMultiplier="1.2"/>
+          <ServiceCheck Name="MSSQLSERVER" Alias="sqlservercheck" TTLMultiplier="2.5"/>
           <PortCheck Name="webserver" Port="80"/>
     -->
   </Checks>


### PR DESCRIPTION
So far, it looks like a multiplier of 2.5 is optimal to account for collection delays or network latency. This change updates that multiplier.