### PR TITLE
Fix for instances of 0 ram bytes detected on Windows fixes #32

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,6 @@
 ## vNext
 - Improved ReadSystemChecks config to make it more clear where check entries should be placed.
+- Fixed Total Physical Memory detection for certain EC2 types
 
 ## v0.10.5
 - Handle null response in HTTP checks

--- a/src/CollectdWinService/Properties/AssemblyInfo.cs
+++ b/src/CollectdWinService/Properties/AssemblyInfo.cs
@@ -35,4 +35,4 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("0.10.5.*")]
+[assembly: AssemblyVersion("0.10.6.*")]

--- a/src/CollectdWinService/ReadWindowsAttributesPlugin.cs
+++ b/src/CollectdWinService/ReadWindowsAttributesPlugin.cs
@@ -198,6 +198,19 @@ namespace Netuitive.CollectdWin
                 {                    
                     totalRAM += Convert.ToInt64(queryObj["Capacity"]);
                 }
+		if (totalRAM <= 0)
+		{
+			ConnectionOptions altconnection = new ConnectionOptions();
+			altconnection.Impersonation = ImpersonationLevel.Impersonate;
+			ManagementScope altscope = new ManagementScope("\\\\.\\root\\CIMV2", altconnection);
+			scope.Connect();
+			ObjectQuery altquery = new ObjectQuery("SELECT * FROM Win32_ComputerSystem");
+			ManagementObjectSearcher altsearcher = new ManagementObjectSearcher(altscope, altquery);
+			foreach (ManagementObject altqueryObj in altsearcher.Get())
+			{
+				    totalRAM += Convert.ToInt64(altqueryObj["TotalPhysicalMemory"]);
+			}
+		}
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Fix for m5 and c5 type EC2s which cannot query Win32_PhysicalMemory, likely due to smBIOS differences.